### PR TITLE
feat(conditional): add support for conditional nesting

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,6 @@ To define attributes of an element, use the following syntax:
 
 ```yaml
 elements:
-  # Define an element with an attribute by specifying the
-  # value and attributes keys
   ContactInformaiton:
     value: preferred_contact_value
     attributes:
@@ -149,7 +147,52 @@ The output of the aboved YAML template will be:
 <ContactInformation type="email">jsmith@email.com</ContactInformation>
 ```
 
+### Conditional Elements
+
+Jexml supports standard conditional logic using the Jexl syntax inline for elements, for example:
+
+```yaml
+elements:
+  IsAdmin: type === 'admin' # Boolean
+  Role: type === 'admin' ? 'Administrator' : 'User' # Ternary
+```
+
+The output of the above YAML template will be:
+
+```xml
+<IsAdmin>true</IsAdmin>
+<Role>Administrator</Role>
+```
+
+To define conditional elements structures, use the following syntax, specifying the condition key with a Jexl expression and the elements key with the child elements:
+
+```yaml
+elements:
+  Permissions:
+    condition: type === 'admin' # Jexl condition syntax
+    elements:
+      ReadAccess: true
+      WriteAccess: true
+```
+
+The output of the above YAML template will be:
+
+```xml
+<Permissions>
+  <ReadAccess>true</ReadAccess>
+  <WriteAccess>true</WriteAccess>
+</Permissions>
+```
+
 ### Arrays
+
+Jexml supports all Jexl array functions and methods for defining arrays of elements.
+
+```yaml
+FavoriteColor: colors[0] # Probably their favorite since it's first
+```
+
+Additionally, array output can be defined using the suffix `[]` for the key along with `elements` key with the `as` and `from` keys to define the array element name and the array reference, respectively.
 
 Given the following JSON data:
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,6 +77,13 @@ export class Jexml {
       .join('');
   }
 
+  private parseConditional(node: Node, context: Context) {
+    const evaluated = jexl.evalSync(node.condition, context);
+    if (evaluated) {
+      return this.parseObject(node.elements, context);
+    }
+  }
+
   // Creates attribute string from map
   private buildAttributes(attributes: Primitive, context: Context) {
     return Object.keys(attributes)
@@ -105,6 +112,9 @@ export class Jexml {
             element,
             this.buildAttributes(node.attributes, context)
           );
+          // OBJECT WITH CONDITON
+        } else if (Object.keys(node).includes('condition')) {
+          return this.parseConditional(node, context);
           // OBJECT WITH VALUE
         } else {
           return this.parseObject(node, context);

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -94,7 +94,18 @@ describe('Jexml', () => {
     }).convert(fixture);
     expect(xml).toContain('<FirstName id="1">John</FirstName>');
   });
-  it('should support conditional elements', () => {
+  it('should support inline conditional evaluation', () => {
+    const config = `
+    root: Record
+    elements:
+      CompanyMatch: "company.name == 'Acme Inc' ? company.name : ''"
+    `;
+    const xml = new Jexml({
+      templateString: config,
+    }).convert(fixture);
+    expect(xml).toContain('<CompanyMatch>Acme Inc</CompanyMatch>');
+  });
+  it('should support conditional elements with children nodes', () => {
     const config = `
     root: Record
     elements:

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -94,6 +94,26 @@ describe('Jexml', () => {
     }).convert(fixture);
     expect(xml).toContain('<FirstName id="1">John</FirstName>');
   });
+  it('should support conditional elements', () => {
+    const config = `
+    root: Record
+    elements:
+      CompanyMatch:
+        condition: company.name == 'Acme Inc'
+        elements:
+          NameMatched: company.name
+      CompanyNoMatch:
+        condition: company.name != 'Acme Inc'
+        elements:
+          NameNotMatched: company.name
+    `;
+    const xml = new Jexml({
+      templateString: config,
+    }).convert(fixture);
+    expect(xml).toContain('<CompanyMatch>');
+    expect(xml).toContain('<NameMatched>Acme Inc</NameMatched>');
+    expect(xml).not.toContain('<CompanyNoMatch>');
+  });
   it('should support array elements', () => {
     const config = `
     root: Record


### PR DESCRIPTION
Adds an evaluator `condition` (with `elements` definition) for building conditional structures with Jexl syntax. Example:

```yaml
elements:
  Permissions:
    condition: type === 'admin' # Jexl condition syntax
    elements:
      ReadAccess: true
      WriteAccess: true
```

The output of the above YAML template will be:

```xml
<Permissions>
  <ReadAccess>true</ReadAccess>
  <WriteAccess>true</WriteAccess>
</Permissions>
```