### PR TITLE
feat(jexl-methods): add support for using functions, transforms, and binary ops using Jexl notation

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,75 @@ The output of the above YAML template will be:
 </Friends>
 ```
 
+### Custom Functions
+
+Custom functions can be defined and used in the template by passing them to the Jexml instance:
+
+```typescript
+const jexml = new Jexml({
+  templateString: config,
+  functions: {
+    concat: (...args) => args.join(''),
+  },
+});
+```
+
+Converting with the following template:
+
+```yaml
+elements:
+  FullName: concat(first_name, ' ', last_name)
+```
+
+Would output `<FullName>John Doe</FullName>`.
+
+## Custom Transforms
+
+Custom transforms can be defined and used in the template by passing them to the Jexml instance:
+
+```typescript
+const jexml = new Jexml({
+  templateString: config,
+  transforms: {
+    uppercase: (value) => value.toUpperCase(),
+  },
+});
+```
+
+Converting with the following template:
+
+```yaml
+elements:
+  FirstName: first_name|uppercase
+```
+
+Would output `<FirstName>JOHN</FirstName>`.
+
+## Custom Binary Operators
+
+Custom binary operators can be defined and used in the template by passing them to the Jexml instance:
+
+```typescript
+const jexml = new Jexml({
+  templateString: config,
+  binaryOperators: {
+    add: {
+      precedence: 1,
+      fn: (left, right) => left + right,
+    },
+  },
+});
+```
+
+Converting with the following template:
+
+```yaml
+elements:
+  Total: 1 add 2
+```
+
+Would output `<Total>3</Total>`.
+
 ## Development
 
 ### Install Dependencies

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,15 @@ type Config = {
   templateString?: string;
   formatSpacing?: number | string;
   ignoreUndefined?: boolean;
+  tranforms?: Record<string, (value: any, ...args: any[]) => any>;
+  functions?: Record<string, (value: any, ...args: any[]) => any>;
+  binaryOps?: Record<
+    string,
+    {
+      precedence: number;
+      fn: (left: any, right: any) => any;
+    }
+  >;
 };
 type Context = Record<string, any>;
 type Node = Record<string, any>;
@@ -30,6 +39,31 @@ export class Jexml {
     this.template = parse(tmpl);
     this.formatSpacing = config.formatSpacing;
     this.ignoreUndefined = config.ignoreUndefined === true ? false : true;
+
+    // Add custom functions to Jexl
+    if (config.functions) {
+      for (const fn in config.functions) {
+        jexl.addFunction(fn, config.functions[fn]);
+      }
+    }
+
+    // Add custom transforms to Jexl
+    if (config.tranforms) {
+      for (const transform in config.tranforms) {
+        jexl.addTransform(transform, config.tranforms[transform]);
+      }
+    }
+
+    // Add custom binary operators to Jexl
+    if (config.binaryOps) {
+      for (const operator in config.binaryOps) {
+        jexl.addBinaryOp(
+          operator,
+          config.binaryOps[operator].precedence,
+          config.binaryOps[operator].fn
+        );
+      }
+    }
   }
 
   // Abstract the creation of XML elements

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -35,7 +35,7 @@ describe('Jexml', () => {
     expect(xml).toContain('<FirstName>John</FirstName>');
     expect(xml).toContain('<LastName>Doe</LastName>');
   });
-  it('should be replace value() with literal', () => {
+  it('should replace value() with literal', () => {
     const config = `
     root: Record
     elements:
@@ -112,6 +112,51 @@ describe('Jexml', () => {
     expect(xml).toContain('<Friends>');
     expect(xml).toContain('<FirstName>Jane</FirstName>');
     expect(xml).toContain('<LastName>Doe</LastName>');
+  });
+  it('should support ability to add custom functions', () => {
+    const config = `
+    root: Record
+    elements:
+      FullName: concat(first_name, " ", last_name)
+    `;
+    const xml = new Jexml({
+      templateString: config,
+      functions: {
+        concat: (...args) => args.join(''),
+      },
+    }).convert(fixture);
+    expect(xml).toContain('<FullName>John Doe</FullName>');
+  });
+  it('should support ability to add custom transforms', () => {
+    const config = `
+    root: Record
+    elements:
+      Age: age|double
+    `;
+    const xml = new Jexml({
+      templateString: config,
+      tranforms: {
+        double: (value) => value * 2,
+      },
+    }).convert(fixture);
+    expect(xml).toContain('<Age>60</Age>');
+  });
+  it('should support ability to add custom binary operators', () => {
+    const config = `
+    root: Record
+    elements:
+      Age: age add 10
+    `;
+    const xml = new Jexml({
+      templateString: config,
+      binaryOps: {
+        add: {
+          precedence: 10,
+          fn: (left, right) => left + right,
+        },
+      },
+    }).convert(fixture);
+    expect(xml).toContain('<Age>40</Age>');
   });
   it('should stream xml when called with stream() method', (done) => {
     const config = `


### PR DESCRIPTION
### Custom Functions

Custom functions can be defined and used in the template by passing them to the Jexml instance:

```typescript
const jexml = new Jexml({
  templateString: config,
  functions: {
    concat: (...args) => args.join(''),
  },
});
```

Converting with the following template:

```yaml
elements:
  FullName: concat(first_name, ' ', last_name)
```

Would output `<FullName>John Doe</FullName>`.

## Custom Transforms

Custom transforms can be defined and used in the template by passing them to the Jexml instance:

```typescript
const jexml = new Jexml({
  templateString: config,
  transforms: {
    uppercase: (value) => value.toUpperCase(),
  },
});
```

Converting with the following template:

```yaml
elements:
  FirstName: first_name|uppercase
```

Would output `<FirstName>JOHN</FirstName>`.

## Custom Binary Operators

Custom binary operators can be defined and used in the template by passing them to the Jexml instance:

```typescript
const jexml = new Jexml({
  templateString: config,
  binaryOperators: {
    add: {
      precedence: 1,
      fn: (left, right) => left + right,
    },
  },
});
```

Converting with the following template:

```yaml
elements:
  Total: 1 add 2
```

Would output `<Total>3</Total>`.